### PR TITLE
Houli/mini vro api gateway

### DIFF
--- a/hypertension/dc-7101-algorithms/Makefile
+++ b/hypertension/dc-7101-algorithms/Makefile
@@ -23,17 +23,12 @@ test: ## Pytest with watch enabled. No other steps.
 	cd ./$(PYTHON_PROJECT_DIR); \
 	$(POETRY) run ptw -c -- --capture=no;
 
-.PHONY: build
-build: ## Poetry install and sam build.
-	make poetry-install
-	$(SAM) build
-
 .PHONY: deploy-guided
 deploy-guided: ## Build and sam deploy --guided.
-	make build
+	$(SAM) build
 	$(SAM) deploy --guided --capabilities CAPABILITY_NAMED_IAM
 
 .PHONY: deploy
 deploy: ## Build and sam deploy.
-	make build
+	$(SAM) build
 	$(SAM) deploy

--- a/hypertension/dc-7101-algorithms/Makefile
+++ b/hypertension/dc-7101-algorithms/Makefile
@@ -31,4 +31,4 @@ deploy-guided: ## Build and sam deploy --guided.
 .PHONY: deploy
 deploy: ## Build and sam deploy.
 	$(SAM) build
-	$(SAM) deploy
+	$(SAM) deploy --no-confirm-changeset

--- a/hypertension/dc-7101-algorithms/docs/design-notes.md
+++ b/hypertension/dc-7101-algorithms/docs/design-notes.md
@@ -1,0 +1,26 @@
+# Mini VRO Design Notes
+
+## Authentication
+
+The Mini VRO exposes the Lambda function as a REST API via an AWS API Gateway.
+
+_A_ way (not recommended) to have an authentication mechanism for your AWS API Gateway API is to have, associated to your API
+- An AWS API Gateway Usage Plan associated to your API
+- An AWS API Gateway API Key associated to your Usage Plan
+- And configure your API Gateway endpoints to require this API Key.
+
+Do note...
+
+AWS API Gateway API Keys are not intended for authentication. API Keys are meant to control access in terms of API call quotas and throttling, and to monitor usage. However, they work as an authentication mechanism in that if your API is setup as described above, and someone tries to access the API without the API Key, AWS API Gateway will return to them an HTTP status 403 "Forbidden" with response body
+
+```
+{
+    "message": "Forbidden"
+}
+```
+
+AWS, in their documentation, recommends other mechanisms be used for controlling authentication. Though the documentation doesn't say, some obvious reasons for this seem to be that API Keys do not offer flexible authentication features like other mechanisms do.
+
+However, the VRO is a unique case. It only has a single client--VA.gov.
+
+Thus, we are at least, for the time being, using AWS API Keys to control authentication.

--- a/hypertension/dc-7101-algorithms/py-root/lib/main.py
+++ b/hypertension/dc-7101-algorithms/py-root/lib/main.py
@@ -1,4 +1,12 @@
 from typing import Dict
 
 def main(event: Dict):
-    return {"statusCode": 200, "body": "test body"}
+    return {
+        "statusCode": 200,
+        "headers": {
+            "Access-Control-Allow-Headers" : "Content-Type",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "OPTIONS,POST"
+        },
+        "body": "test body"
+    }

--- a/hypertension/dc-7101-algorithms/py-root/test/main_test.py
+++ b/hypertension/dc-7101-algorithms/py-root/test/main_test.py
@@ -2,4 +2,13 @@ from lib.main import main
 
 def test_main():
     test_event = {"irrelevant": "value"}
-    assert main(test_event) == {"statusCode": 200, "body": "test body"}
+    assert main(test_event) == {
+        "statusCode": 200,
+        "headers": {
+            "Access-Control-Allow-Headers" : "Content-Type",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "OPTIONS,POST"
+        },
+        "body": "test body"
+    }
+

--- a/hypertension/dc-7101-algorithms/template.yaml
+++ b/hypertension/dc-7101-algorithms/template.yaml
@@ -23,6 +23,17 @@ Resources:
         Type: AWS::Serverless::Api
         Properties:
             StageName: Test
+            Auth:
+                ApiKeyRequired: true
+                UsagePlan:
+                    UsagePlanName: MiniVroUsagePlan
+                    CreateUsagePlan: PER_API
+                    Quota:
+                        Period: MONTH
+                        Limit: 10000
+                    Throttle:
+                        BurstLimit: 100
+                        RateLimit: 100
     VroHtnDataProcessorRole:
         Type: AWS::IAM::Role
         Properties:

--- a/hypertension/dc-7101-algorithms/template.yaml
+++ b/hypertension/dc-7101-algorithms/template.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
-Description: Hypertension Data Processor
+Description: Virtual Regional Office - Hypertension Data Processor
 
 Resources:
     VroHtnDataProcessor:
@@ -12,6 +12,17 @@ Resources:
             Handler: app.lambda_handler
             Runtime: python3.9
             Role: !GetAtt VroHtnDataProcessorRole.Arn
+            Events:
+                VroCalculationAlgorithms:
+                    Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+                    Properties:
+                        Path: /calculate
+                        Method: post
+                        RestApiId: !Ref VroHtnDataProcessorRestApi
+    VroHtnDataProcessorRestApi:
+        Type: AWS::Serverless::Api
+        Properties:
+            StageName: Test
     VroHtnDataProcessorRole:
         Type: AWS::IAM::Role
         Properties:
@@ -20,12 +31,12 @@ Resources:
             AssumeRolePolicyDocument:
                 Version: '2012-10-17'
                 Statement:
-                - Effect: Allow
-                  Action: sts:AssumeRole
-                  # TODO: Limit this down. Allowing all lambda to assume this role is too much. Limit it
-                  # to just the ARN of your lambda function.
-                  Principal:
-                      Service: lambda.amazonaws.com
+                  - Effect: Allow
+                    Action: sts:AssumeRole
+                    # TODO: Limit this down. Allowing all lambda to assume this role is too much. Limit it
+                    # to just the ARN of your lambda function.
+                    Principal:
+                        Service: lambda.amazonaws.com
                 # TODO: Cleanup this comment: It's unfortunate that they use the word "Role" in the name, because it's actually a policy.
             ManagedPolicyArns:
             - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole


### PR DESCRIPTION
# Info

This PR adds to the Mini VRO (via it's CF/SAM stack):
- An AWS API Gateway API
- An AWS API Gateway Usage Plan with quota and throttle limits, which is tied to the API
- An AWS API Gateway API Key, which is tied to the Usage Plan
- HTTP response headers to make Lambda <> API Gateway integration work (per AWS documentation)

See `hypertension/dc-7101-algorithms/docs/design-notes.md` for details.

# Additional, Unrelated Fix

I updated the Makefile to make the SAM commands not dependent on Poetry install, because they don't.

# To Test

## 1. Deploy

`make deploy` (or `make deploy-guided`) to an AWS cloud.

## 2. Lookup Config and Credentials

Log into the console, go to AWS API Gateway. Find the associated API <> Usage Plan <> API Key that was created by the Mini VRO's CF/SAM `template.yaml`.

- The API will have "stages"; find the one named "Test". (This is how it's defined in `template.yaml`.) From the console, get the "Invocation URL" for that stage. (In the left hand bar, select `Stages` >> select the `Test` stage >> you should see the Invocation URL.)

- In the AWS console for API Gateway, in the left-hand sidebar, select `API Keys`. Get the value of the API Key that was auto-generated as a part of your SAM deploy (i.e. part of your `make deploy`).

## 3. Invoke

Submit a POST request to the Invocation URL

Include an HTTP header that is
`x-api-key: THE_VALUE_OF_THE_API_KEY`

Include a JSON body that can be literally anything.

You should get a 200 back with HTTP response body set to string `test body`.