### PR TITLE
Refactor history_of_diastolic_bp to compare counts instead of division

### DIFF
--- a/hypertension/dc-7101-algorithms/py-root/lib/algorithms/bp_history.py
+++ b/hypertension/dc-7101-algorithms/py-root/lib/algorithms/bp_history.py
@@ -14,12 +14,16 @@ def history_of_diastolic_bp(request_body):
     bp_readings = request_body["bp"]
     bp_readings_length = len(bp_readings)
     readings_greater_or_equal_to_one_hundred = 0
+    readings_less_than_one_hundred = 0
 
     if bp_readings_length > 0:
         for reading in bp_readings:
             if reading["diastolic"] >= 100:
                 readings_greater_or_equal_to_one_hundred += 1
-        diastolic_history_calculation["diastolic_bp_predominantly_100_or_more"] = True if readings_greater_or_equal_to_one_hundred / bp_readings_length >=.5 else False
+            else:
+                readings_less_than_one_hundred += 1
+
+        diastolic_history_calculation["diastolic_bp_predominantly_100_or_more"] = True if readings_greater_or_equal_to_one_hundred >= readings_less_than_one_hundred else False
     else:
         diastolic_history_calculation["success"] = False
 


### PR DESCRIPTION
# NOTE (1/11): This is OBE'd by the fact that we're rewriting this algorithm

## General Overview
(Text taken from [MCP-1044](https://amida.atlassian.net/browse/MCP-1044))
I (Houli) am concerned the processor might not do the division math correctly every time [in the history of diastolic algorithm], and perhaps you could end up with a case where the total number of readings is even, and the number of those readings >= 100 is equal to the number < 100, and when the division happens, it would come out to 4.99999999999.

Have it count the number of readings >= 100 vs < 100 and compare the two counts.

(see https://github.com/department-of-veterans-affairs/Virtual-Regional-Office/pull/29/files#r772019395 for initial comment)

## Testing
To test, make sure you're in the `hypertension/dc-7101-algorithms/` dir, and run `make test`. 