### PR TITLE
Change BP sufficiency algo to take highest values

### DIFF
--- a/hypertension/dc-7101-algorithms/py-root/lib/algorithms/bp_sufficiency.py
+++ b/hypertension/dc-7101-algorithms/py-root/lib/algorithms/bp_sufficiency.py
@@ -38,9 +38,14 @@ def sufficient_to_autopopulate (request_body):
     elif len(valid_bp_readings) > 1 and bp_readings_meet_date_specs(date_of_claim, valid_bp_readings):
 
         if len(valid_bp_readings) == 2:
-            most_recent_reading = sorted(valid_bp_readings, key=lambda d: d["date"])[-1]
-            predominance_calculation["predominant_diastolic_reading"] = most_recent_reading["diastolic"]
-            predominance_calculation["predominant_systolic_reading"] = most_recent_reading["systolic"]
+            first_reading = valid_bp_readings[0]
+            second_reading = valid_bp_readings[1]
+            
+            predominant_diastolic_value = first_reading["diastolic"] if first_reading["diastolic"] > second_reading["diastolic"] else second_reading["diastolic"] 
+            predominant_systolic_value = first_reading["systolic"] if first_reading["systolic"] > second_reading["systolic"] else second_reading["systolic"] 
+
+            predominance_calculation["predominant_diastolic_reading"] = predominant_diastolic_value
+            predominance_calculation["predominant_systolic_reading"] = predominant_systolic_value
         elif len(valid_bp_readings) > 2:
             bucketed_diastolic_readings = tally_diastolic_counts(valid_bp_readings)
             predominance_calculation["predominant_diastolic_reading"] = calculate_reading_from_buckets(bucketed_diastolic_readings, valid_bp_readings, True)

--- a/hypertension/dc-7101-algorithms/py-root/lib/algorithms/bp_sufficiency.py
+++ b/hypertension/dc-7101-algorithms/py-root/lib/algorithms/bp_sufficiency.py
@@ -40,12 +40,10 @@ def sufficient_to_autopopulate (request_body):
         if len(valid_bp_readings) == 2:
             first_reading = valid_bp_readings[0]
             second_reading = valid_bp_readings[1]
-            
-            predominant_diastolic_value = first_reading["diastolic"] if first_reading["diastolic"] > second_reading["diastolic"] else second_reading["diastolic"] 
-            predominant_systolic_value = first_reading["systolic"] if first_reading["systolic"] > second_reading["systolic"] else second_reading["systolic"] 
 
-            predominance_calculation["predominant_diastolic_reading"] = predominant_diastolic_value
-            predominance_calculation["predominant_systolic_reading"] = predominant_systolic_value
+            predominance_calculation["predominant_diastolic_reading"] = first_reading["diastolic"] if first_reading["diastolic"] > second_reading["diastolic"] else second_reading["diastolic"] 
+            predominance_calculation["predominant_systolic_reading"] = first_reading["systolic"] if first_reading["systolic"] > second_reading["systolic"] else second_reading["systolic"] 
+
         elif len(valid_bp_readings) > 2:
             bucketed_diastolic_readings = tally_diastolic_counts(valid_bp_readings)
             predominance_calculation["predominant_diastolic_reading"] = calculate_reading_from_buckets(bucketed_diastolic_readings, valid_bp_readings, True)

--- a/hypertension/dc-7101-algorithms/py-root/test/bp_sufficiency_test.py
+++ b/hypertension/dc-7101-algorithms/py-root/test/bp_sufficiency_test.py
@@ -24,7 +24,7 @@ from lib.algorithms.bp_sufficiency import sufficient_to_autopopulate
             {
                 "success": True,
                 "predominant_diastolic_reading": 115,
-                "predominant_systolic_reading": 180
+                "predominant_systolic_reading": 200
             },
         ),
         # 2 reading test case with one out of range date
@@ -52,7 +52,7 @@ from lib.algorithms.bp_sufficiency import sufficient_to_autopopulate
             {
                 "success": True,
                 "predominant_diastolic_reading": 115,
-                "predominant_systolic_reading": 180
+                "predominant_systolic_reading": 200
             },
         ),
         # +2 reading test case with no out of range dates

--- a/hypertension/dc-7101-algorithms/py-root/test/main_test.py
+++ b/hypertension/dc-7101-algorithms/py-root/test/main_test.py
@@ -37,7 +37,7 @@ from lib.main import main
                     "predominance_calculation": {
                         "success": True,
                         "predominant_diastolic_reading": 115,
-                        "predominant_systolic_reading": 180
+                        "predominant_systolic_reading": 200
                     },
                     "diastolic_history_calculation": {
                         "diastolic_bp_predominantly_100_or_more": True,


### PR DESCRIPTION
## Overview
After talking to our client, we realized that the [logic](https://amida.atlassian.net/browse/MCP-1014) we had used to create the BP sufficiency algorithm (when two readings were present) was incorrect.

>If there are 2 readings…
The most recent diastolic reading is the Predominant Diastolic Reading (PDR).
The most recent systolic reading is the Predominant Systolic Reading (PSR).

The algorithm should instead take the highest diastolic and highest systolic values, so I've updated the logic and tests accordingly
This references [MCP-1049](https://amida.atlassian.net/browse/MCP-1049)

## Testing
run `make test` in ./hypertension/dc-7101-algorithms